### PR TITLE
Fix incorrect letter inserting

### DIFF
--- a/pkg/engine/swapper.go
+++ b/pkg/engine/swapper.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"math/rand"
+	"strconv"
 	"unicode"
 
 	"github.com/chutified/smart-passwd/pkg/utils"
@@ -78,7 +79,12 @@ func (s *Swapper) ExtraSec(str string, l int16) string {
 	// insert numbers
 	for a := int16(0); a < nums; a++ {
 		i := s.rand.Intn(len(ss) + 1)
-		ss = append(append(ss[:i], rune(s.Num())), ss[i:]...)
+		n := []rune(strconv.Itoa(int(s.Num())))[0]
+
+		// insert rune 'n' into array 'ss' at index 'i'
+		ss = append(ss, 0)
+		copy(ss[i+1:], ss[i:])
+		ss[i] = n
 	}
 
 	// insert special symbols


### PR DESCRIPTION
The code would shift the whole sub-array of the password ([]rune) to
insert a letter. This commit fix this wrong behaviour by appending
an empty item at the end of the aray and copy its content to the 'final'
index (shift by copy).